### PR TITLE
fix: [#2] Consistent image size

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -144,6 +144,7 @@ const Wrapper = styled.div`
   flex-wrap: wrap;
   align-items: center;
   justify-content: space-between;
+  gap: 150px;
 `;
 
 const Controls = styled.div`

--- a/src/components/Slideshow.js
+++ b/src/components/Slideshow.js
@@ -20,11 +20,14 @@ const ImageWrapper = styled.div`
   overflow: hidden;
   display: flex;
   justify-content: center;
+  align-items: center;
+  height: 600px;
+  width: 600px;
   img {
     object-fit: cover;
     display: block;
-    max-width: 600px;
-    max-height: 600px;
+    width: 100%;
+    height: 100%;
     padding: 20px;
   }
 `;


### PR DESCRIPTION
### **Scope of change**
- Fixed image sizes to be `600px` height and width.
- Added a gap between image and "Who's that Pokémon" section because they were very close to each other.

### Screenshot
<img width="1268" alt="image" src="https://github.com/minnayu/guess-that-pokemon/assets/87971509/712f33c6-ad02-41ec-b441-1d4616cf5f00">

### Notes
This fixes #2 